### PR TITLE
Avoid SyntaxError from the browser.

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ tracker at <a href="http://www.markus-lanthaler.com/hydra/api-demo/" data-action
   </div>
 
   <div class="modal hide fade" id="operationsModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-<script id="operationsModal-template">
+<script type="underscore/template" id="operationsModal-template">
     <form id="operationsForm" class="modal-form">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -242,7 +242,7 @@ tracker at <a href="http://www.markus-lanthaler.com/hydra/api-demo/" data-action
 </script>
   </div>
 
-  <script id="documentation-template" style="display:none">
+  <script type="underscore/template" id="documentation-template" style="display:none">
     <p><%= docu.description.replace(/\n/g, '<br>') %></p>
     <table class="table table-hover">
       <tbody>


### PR DESCRIPTION
index.html contains a few html templates wrapped in <script> tags.
The browser tries to parse these as javascript, finds HTML and issues
a SyntaxError.  Adding a type="" argument the browser [1] doesn't know
how to parse will make the browser ignore the tag, but still keeping
it available for javascript to read.

In theory HTML5 has a <template> element for this purpose, but I saw
other errors when using that.

[1] Tested with Firefox 24 on Ubuntu.
